### PR TITLE
Implement persistent snapshot-set cache

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@shutter/api": "^0.0.0",
+    "@shutter/metacache": "^0.0.0",
     "@shutter/shutterrc": "^0.0.0",
     "dashify": "^1.0.0",
     "mkdirp": "^0.5.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import { readFile } from 'mz/fs'
 import * as path from 'path'
 import kebabCase from 'dashify'
 import defaultLayout from './default-layout'
+import { openSnapshotSetsCache, updateSnapshotSetCache } from './snapshot-sets-cache'
 import {
   createFileFromBuffer,
   createSnapshot,
@@ -60,6 +61,7 @@ const createShutter = (testsDirectoryPath: string, shutterOptions: ShutterCreati
 
   let finishCalled: boolean = false
   let tests: TestCase[] = []
+  const snapshotSetsCachePromise = openSnapshotSetsCache()
 
   return {
     async snapshot (testName: string, html: HTMLString, options: SnapshotOptions = {}) {
@@ -110,6 +112,9 @@ const createShutter = (testsDirectoryPath: string, shutterOptions: ShutterCreati
       if (testsFailed && !updateSnapshots) {
         throw new Error(`Shutter tests failed. Tests:\n${formatTestResultsOverview(results)}\n${inspectionLine}`)
       } else {
+        const snapshotSetsCache = await snapshotSetsCachePromise
+        await updateSnapshotSetCache(snapshotSetsCache, results)
+
         console.log(formatSuccessMessage(results))
         console.log(inspectionLine)
       }

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -13,6 +13,7 @@ export interface TestCase {
 
 export interface TestResult {
   expectationFileNotPresent: boolean,
+  expectationFilePath: string,
   match: boolean,
   similarity: number,
   snapshotID: string,
@@ -44,6 +45,7 @@ export const createResultData = async (test: TestCase): Promise<TestResult> => {
 
   return {
     expectationFileNotPresent: test.expectationFileNotPresent,
+    expectationFilePath: test.expectationFilePath,
     match,
     similarity,
     snapshotID: snapshot.id,

--- a/packages/core/src/snapshot-sets-cache.ts
+++ b/packages/core/src/snapshot-sets-cache.ts
@@ -1,0 +1,45 @@
+import { getSnapshotSetsCachePath, openJSONCache, JSONCache } from '@shutter/metacache'
+import { TestResult } from './results'
+
+export type SnapshotSetsCache = JSONCache<SnapshotSetCacheEntry | LatestSnapshotSetEntry>
+
+export interface SnapshotSetCacheEntry {
+  id: string,
+  snapshots: {
+    id: string,
+    snapshotFilePath: string,
+    testName: string
+  }[]
+}
+
+export type LatestSnapshotSetEntry = string
+
+const dedupe = <Entry>(array: Entry[]): Entry[] => Array.from(new Set(array))
+const lastItem = <Entry>(array: Entry[]) => array[array.length - 1]
+
+export const openSnapshotSetsCache = async (): Promise<SnapshotSetsCache> => {
+  const cache = await openJSONCache(getSnapshotSetsCachePath())
+  return cache
+}
+
+export const updateSnapshotSetCache = async (cache: SnapshotSetsCache, results: TestResult[]) => {
+  const snapshotSetIDs = dedupe(results.map(result => result.snapshotSetID))
+
+  // Normally there should only be one snapshot set for one test run, but better be safe than sorry...
+  for (const snapshotSetID of snapshotSetIDs) {
+    const resultsInSnapshotSet = results.filter(result => result.snapshotSetID === snapshotSetID)
+
+    const snapshots = resultsInSnapshotSet.map(result => ({
+      id: result.snapshotID,
+      snapshotFilePath: result.expectationFilePath,
+      testName: result.testName
+    }))
+
+    await cache.save(snapshotSetID, {
+      id: snapshotSetID,
+      snapshots
+    })
+  }
+
+  await cache.save('.latest', lastItem(snapshotSetIDs))
+}

--- a/packages/core/test/helpers/fs.ts
+++ b/packages/core/test/helpers/fs.ts
@@ -1,0 +1,27 @@
+import * as fs from 'mz/fs'
+
+export const isDirectory = async (dirPath: string) => {
+  try {
+    const stat = await fs.stat(dirPath)
+    return stat.isDirectory()
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false
+    } else {
+      throw error
+    }
+  }
+}
+
+export const isFile = async (filePath: string) => {
+  try {
+    const stat = await fs.stat(filePath)
+    return stat.isFile()
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false
+    } else {
+      throw error
+    }
+  }
+}

--- a/packages/core/test/metacache.test.ts
+++ b/packages/core/test/metacache.test.ts
@@ -1,0 +1,44 @@
+import test from 'ava'
+import * as fs from 'mz/fs'
+import * as path from 'path'
+import * as os from 'os'
+import createShutter from '../src'
+import { isDirectory, isFile } from './helpers/fs'
+
+require('dotenv').load()
+
+test.serial('snapshot set cache is updated', async t => {
+  const shutter = createShutter(__dirname)
+  await shutter.snapshot('button', '<button>Click me!</button>')
+  await shutter.snapshot('link', '<a href="https://shutter.sh/">Proceed to shutter.sh</a>')
+  const results = await shutter.finish()
+
+  // Test overall cache:
+
+  const snapshotSetsCachePath = path.join(os.homedir(), '.shutter', 'cache', 'snapshotsets')
+  t.true(await isDirectory(snapshotSetsCachePath))
+
+  const snapshotSetCacheItemPath = path.join(snapshotSetsCachePath, results[0].snapshotSetID)
+  t.true(await isFile(snapshotSetCacheItemPath))
+
+  // Test cache item:
+
+  const cacheItem = JSON.parse(await fs.readFile(snapshotSetCacheItemPath, 'utf8'))
+  t.is(cacheItem.id, results[0].snapshotSetID)
+  t.is(cacheItem.snapshots.length, 2)
+
+  t.is(cacheItem.snapshots[0].id, results[0].snapshotID)
+  t.is(cacheItem.snapshots[0].snapshotFilePath, path.join(__dirname, 'snapshots', 'button.png'))
+  t.is(cacheItem.snapshots[0].testName, 'button')
+  t.is(cacheItem.snapshots[1].id, results[1].snapshotID)
+  t.is(cacheItem.snapshots[1].snapshotFilePath, path.join(__dirname, 'snapshots', 'link.png'))
+  t.is(cacheItem.snapshots[1].testName, 'link')
+
+  // Test pointer to latest snapshot set:
+
+  const latestSnapshotSetPath = path.join(snapshotSetsCachePath, '.latest')
+  t.true(await isFile(latestSnapshotSetPath))
+
+  const latestSnapshotSetID = JSON.parse(await fs.readFile(latestSnapshotSetPath, 'utf8'))
+  t.is(latestSnapshotSetID, results[0].snapshotSetID)
+})

--- a/packages/core/test/snapshots/.gitignore
+++ b/packages/core/test/snapshots/.gitignore
@@ -1,0 +1,2 @@
+button.png
+link.png

--- a/packages/metacache/README.md
+++ b/packages/metacache/README.md
@@ -1,0 +1,19 @@
+# @shutter/metacache
+
+Managing persistent cache data on disk, like the snapshot sets cache.
+
+## API
+
+### `getSnapshotSetsCachePath(): string`
+
+### `openJSONCache<Value = any>(directoryPath: string): Promise<JSONCache>`
+
+### `JSONCache<Value>`
+
+```ts
+interface JSONCache<Value> {
+  save (key: string, content: Value): Promise<any>
+  read (key: string): Promise<Value>
+  has (key: string): Promise<boolean>
+}
+```

--- a/packages/metacache/package.json
+++ b/packages/metacache/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shutter/metacache",
+  "version": "0.0.0",
+  "license": "MIT",
+  "author": "Andy Wermke (https://github.com/andywer)",
+  "main": "./dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "tslint --project . 'src/**/*.ts' -e '**/*.d.ts'"
+  },
+  "dependencies": {
+    "mkdirp": "^0.5.1",
+    "mz": "^2.7.0"
+  },
+  "devDependencies": {
+    "@types/ini": "^1.3.29",
+    "@types/mkdirp": "^0.5.2",
+    "@types/mz": "^0.0.32",
+    "tslint": "^5.10.0",
+    "tslint-config-standard": "^7.0.0",
+    "typescript": "^2.8.3"
+  }
+}

--- a/packages/metacache/src/index.ts
+++ b/packages/metacache/src/index.ts
@@ -1,0 +1,48 @@
+import * as fs from 'mz/fs'
+import * as path from 'path'
+import * as os from 'os'
+import mkdirpCallback from 'mkdirp'
+
+export interface JSONCache<Value> {
+  save (key: string, content: Value): Promise<any>
+  read (key: string): Promise<Value>
+  has (key: string): Promise<boolean>
+}
+
+const mkdirp = (directoryPath: string) => new Promise((resolve, reject) => mkdirpCallback(directoryPath, error => error ? reject(error) : resolve()))
+
+const isFile = async (filePath: string) => {
+  try {
+    const stat = await fs.stat(filePath)
+    return stat.isFile()
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false
+    } else {
+      throw error
+    }
+  }
+}
+
+export const getSnapshotSetsCachePath = () => path.join(os.homedir(), '.shutter', 'cache', 'snapshotsets')
+
+export const openJSONCache = async <Value = any>(directoryPath: string) => {
+  const getFilePath = (filePath: string) => path.join(directoryPath, filePath)
+
+  // Create directory if it doesn't exist yet
+  await mkdirp(directoryPath)
+
+  const cache: JSONCache<Value> = {
+    save (key: string, content: Value) {
+      return fs.writeFile(getFilePath(key), JSON.stringify(content), 'utf8')
+    },
+    async read (key: string) {
+      const unparsed = await fs.readFile(getFilePath(key), 'utf8')
+      return JSON.parse(unparsed) as Value
+    },
+    has (key: string) {
+      return isFile(getFilePath(key))
+    }
+  }
+  return cache
+}

--- a/packages/metacache/tsconfig.json
+++ b/packages/metacache/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es6",
+    "module": "commonjs",
+    "lib": ["es2015", "es2016", "es2017", "es2017.object"],
+    "declaration": true,
+    "strict": true,
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "./node_modules/*",
+        "../../node_modules/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/metacache/tslint.json
+++ b/packages/metacache/tslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "tslint-config-standard"
+  ],
+  "jsRules": {},
+  "rules": {
+    "await-promise": [true, "Bluebird"]
+  },
+  "rulesDirectory": []
+}


### PR DESCRIPTION
Stores snapshot set ID, snapshot IDs and snapshot file paths per snapshot set, so we can consume that data afterwards in the CLI tool.