### PR TITLE
Deprecate 2nd custom render arg, update docs

### DIFF
--- a/docs/react-tests.md
+++ b/docs/react-tests.md
@@ -38,16 +38,16 @@ It will also print an inspection URL which links to the shutter.sh web app where
 
 You can pass a custom render function to `createReactShutter()` or `shutter.snapshot()`. Use it wrap your components in other components, like context providers.
 
-The render function takes a React element and returns a string of static HTML. The default render function is just a thin wrapper around `ReactDOMServer.renderToStaticMarkup()`.
+The render function takes a React element and returns a promise resolving to a string of static HTML. The default render function, exported as `renderComponent`, is just a thin wrapper around `ReactDOMServer.renderToStaticMarkup()`.
 
 This example sets up a shutter instance that will wrap the components in a Redux store provider:
 
 ```jsx
-import createReactShutter from '@shutter/react'
+import createReactShutter, { renderComponent as baseRender } from '@shutter/react'
 import { Provider } from 'react-redux'
 import store from './store'
 
-const render = (element, baseRender) => {
+const render = (element) => {
   return baseRender(
     <Provider store={store}>
       {element}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,7 +58,7 @@ Creates a shutter instance. You need to pass your testing directory (can usually
 ```ts
 interface ShutterOptions {
   layout?: (htmlContent: string) => string,
-  render?: (reactElement: ReactElement<any>, originalRender: function) => Promise<string>,
+  render?: (reactElement: ReactElement<any>) => Promise<string>,
   snapshotsPath?: string,
   diffOptions?: DiffOptions,
   renderOptions?: RenderOptions
@@ -76,7 +76,7 @@ The returned promise will resolve once the upload is done, but before the render
 ```ts
 interface SnapshotOptions {
   layout?: (htmlContent: string) => string,
-  render?: (reactElement: ReactElement<any>, originalRender: function) => Promise<string>,
+  render?: (reactElement: ReactElement<any>) => Promise<string>,
   diffOptions?: DiffOptions,
   renderOptions?: RenderOptions
 }
@@ -94,22 +94,22 @@ Will throw with a test results summary if snapshots don't match. Prints a succes
 
 ### Custom render function
 
-You can pass a custom render function to `createReactShutter()` or `shutter.snapshot()`. The render function takes a React element and returns a string of static HTML. The default render function is just a thin wrapper around `ReactDOMServer.renderToStaticMarkup()`.
+You can pass a custom render function to `createReactShutter()` or `shutter.snapshot()`. The render function takes a React element and returns a promise resolving to a string of static HTML. The default render function, exported as `renderComponent`, is just a thin wrapper around `ReactDOMServer.renderToStaticMarkup()`.
 
 ```ts
 export type HTMLString = string
 export type BuiltinRenderFunction = (reactElement: ReactElement<any>) => Promise<HTMLString>
-export type RenderFunction = (reactElement: ReactElement<any>, originalRender: BuiltinRenderFunction) => Promise<HTMLString>
+export type RenderFunction = (reactElement: ReactElement<any>) => Promise<HTMLString>
 ```
 
 Use it wrap your components in other components, like context providers:
 
 ```jsx
 import { Provider } from 'react-redux'
-import createReactShutter from '@shutter/react'
+import createReactShutter, { renderComponent as baseRender } from '@shutter/react'
 import store from './store'
 
-const render = (element, baseRender) => {
+const render = (element) => {
   return baseRender(
     <Provider store={store}>
       {element}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,6 +10,11 @@ export { TestResult }
 
 export type HTMLString = string
 export type BuiltinRenderFunction = (reactElement: ReactElement<any>) => Promise<HTMLString>
+
+/**
+ * The 2nd argument to the function (`originalRender`) is deprecated and will be removed soon.
+ * Import the `renderComponent()` function instead.
+ */
 export type RenderFunction = (reactElement: ReactElement<any>, originalRender: BuiltinRenderFunction) => Promise<HTMLString>
 
 export interface ShutterCreationOptions extends CoreShutterCreationOptions {
@@ -20,7 +25,7 @@ export interface SnapshotOptions extends CoreSnapshotOptions {
   render?: RenderFunction
 }
 
-const defaultRender = (element: ReactElement<any>): Promise<HTMLString> => {
+export const renderComponent = (element: ReactElement<any>): Promise<HTMLString> => {
   return Promise.resolve(renderToStaticMarkup(element))
 }
 
@@ -31,9 +36,9 @@ const createReactShutter = (testsDirectoryPath: string, shutterOptions: ShutterC
     ...shutter,
 
     async snapshot (testName: string, element: ReactElement<any>, options: SnapshotOptions = {}) {
-      const render = options.render || shutterOptions.render || defaultRender
+      const render = options.render || shutterOptions.render || renderComponent
 
-      const html = await render(element, defaultRender)
+      const html = await render(element, renderComponent)
       return shutter.snapshot(testName, html, options)
     }
   }


### PR DESCRIPTION
Make custom renderer API a little friendlier. Closes #21.

```diff
+ import createReactShutter, { renderComponent as baseRender } from '@shutter/react'
- import createReactShutter from '@shutter/react'

+ const render = (element) => {
- const render = (element, baseRender) => {
    return baseRender(element)
  }
```
