### PR TITLE
Downgrade inquirer package

### DIFF
--- a/packages/shutter/package.json
+++ b/packages/shutter/package.json
@@ -26,7 +26,7 @@
     "@shutter/shutterrc": "^0.4.0",
     "@types/meow": "^4.0.1",
     "@types/superagent": "^3.5.8",
-    "inquirer": "^5.2.0",
+    "inquirer": "^3.3.0",
     "meow": "^5.0.0",
     "superagent": "^3.8.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3312,7 +3312,26 @@ inquirer@3.2.1:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^5.1.0, inquirer@^5.2.0:
+inquirer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
   dependencies:


### PR DESCRIPTION
v3.3.0 does the same as v5.1.0, but without the huge RxJS dependency.

Reduces the total size of `shutter`'s production dependencies from 29MB to 11MB (!).