### PR TITLE
Make docs page mobile-friendly

### DIFF
--- a/docs/site/_includes/side-menu.njk
+++ b/docs/site/_includes/side-menu.njk
@@ -5,6 +5,7 @@
 {% endmacro %}
 
 <aside class="side-menu">
+  <h2>Navigation</h2>
   <nav class="menu-root">
     {% for home in collections.home %}
       {{ menuItem(home) }}

--- a/docs/site/styles/layout.css
+++ b/docs/site/styles/layout.css
@@ -66,6 +66,40 @@ main > article {
   margin-bottom: 16px;
 }
 
+/* Place side menu below content on mobile */
+@media only screen and (max-width: 650px) {
+  main, main.page-max-width {
+    flex-direction: column-reverse;
+  }
+
+  main > aside {
+    border-right: none;
+  }
+  main > aside.side-menu {
+    margin-top: 0;
+  }
+
+  main > aside.side-menu > h2 {
+    display: block;
+  }
+
+  main > aside.side-menu nav .menu-item {
+    font-size: 125%;
+  }
+
+  main > aside.side-menu nav .current-page {
+    text-decoration: underline;
+  }
+
+  main > article {
+    padding-left: 0;
+  }
+
+  main > article h1 {
+    margin-top: 8px;
+  }
+}
+
 footer {
   position: absolute;
   bottom: 0;

--- a/docs/site/styles/side-menu.css
+++ b/docs/site/styles/side-menu.css
@@ -1,5 +1,5 @@
 .side-menu {
-  margin-top: 24px;
+  margin-top: 28px;
 }
 
 .side-menu nav {

--- a/docs/site/styles/side-menu.css
+++ b/docs/site/styles/side-menu.css
@@ -2,6 +2,11 @@
   margin-top: 28px;
 }
 
+.side-menu > h2 {
+  display: none;
+  margin-top: 0;
+}
+
 .side-menu nav {
   padding: 0;
   padding-left: 0.7em;


### PR DESCRIPTION
On mobile:
- Move main navigation below the main content
- Move navigation menu items further apart and increase font size